### PR TITLE
Add imports to some documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ See some examples here: https://elm-simple-animation-examples.surge.sh/
 Animate HTML, SVG (or any UI Elements) with declarative animations
 
 ```elm
+import Html exposing (Html)
+import Simple.Animated as Animated
+import Simple.Animation as Animation exposing (Animation)
+import Simple.Animation.Property as P
+
 animatedDot : Html msg
 animatedDot =
     Animated.div expandFade [ class "dot" ] []

--- a/src/Simple/Animated.elm
+++ b/src/Simple/Animated.elm
@@ -53,6 +53,11 @@ import Internal.Animation as Animation exposing (Animation)
 
 ### Render an Animated `div`
 
+    import Html exposing (Html)
+    import Simple.Animated as Animated
+    import Simple.Animation as Animation exposing (Animation)
+    import Simple.Animation.Property as P
+
     dot : Html msg
     dot =
         Animated.div expandFade [ class "dot" ] []

--- a/src/Simple/Animation.elm
+++ b/src/Simple/Animation.elm
@@ -95,6 +95,9 @@ type Step
 
 {-| Create an animation with `start` and `end` properties:
 
+    import Simple.Animation as Animation exposing (Animation)
+    import Simple.Animation.Property as P
+
     fadeOut : Animation
     fadeOut =
         Animation.fromTo
@@ -121,6 +124,9 @@ fromTo o from_ to_ =
 
 
 {-| Create an animation with multiple steps:
+
+    import Simple.Animation as Animation exposing (Animation)
+    import Simple.Animation.Property as P
 
     backAndForth : Animation
     backAndForth =
@@ -181,6 +187,9 @@ wait =
 {-| Wait for another animation to complete before animating the next properties:
 
 This animation will `wait` for `1500` milliseconds before animating to the next step
+
+    import Simple.Animation as Animation exposing (Animation)
+    import Simple.Animation.Property as P
 
     finishAfterFadeOut : Animation
     finishAfterFadeOut =


### PR DESCRIPTION
This is a PR for https://github.com/andrewMacmurray/elm-simple-animation/issues/6 

I ended up only adding imports to some of the documentation. I skipped very short examples or where it felt obvious what the imports were. 