### PR TITLE
Add 'Animation.empty' definition for convenience

### DIFF
--- a/src/Simple/Animation.elm
+++ b/src/Simple/Animation.elm
@@ -1,5 +1,5 @@
 module Simple.Animation exposing
-    ( Animation, Millis, fromTo, steps
+    ( Animation, Millis, fromTo, steps, empty
     , Step, step, set, wait, waitTillComplete
     , Option, loop, count, delay
     , linear, easeIn, easeOut, easeInOut, cubic
@@ -151,7 +151,20 @@ steps { options, startAt } steps_ =
             }
         )
 
-
+{-| Create an empty animation:
+    emptyAnimation : Animation
+    enptyAnimation =
+        Animation.empty
+-}
+empty : Animation
+empty =
+    toAnimation
+        (Stepped
+            { options = []
+            , startAt = []
+            , steps   = []
+            }
+        )
 
 -- Step
 

--- a/src/Simple/Animation.elm
+++ b/src/Simple/Animation.elm
@@ -21,6 +21,12 @@ Build up a multi step animation
 
 @docs Step, step, set, wait, waitTillComplete
 
+# Empty
+
+Build an Animation that does nothing.
+
+@docs empty
+
 
 # Options
 


### PR DESCRIPTION
Maybe I am going at this the wrong way, but I thought that adding `Animation.empty` would make it easier to match either no animation or some animation depending on the `model`.

My thinking is 
```elm
expandFade =
    Animation.fromTo
        { duration = 2000
        , options = [ Animation.loop ]
        }
        [ P.opacity 1, P.scale 1 ]
        [ P.opacity 0, P.scale 2 ]


animatedEl
    ( if model.needsAnimation then
          expandFade
      else
          Animation.empty
    )
```

If I am going at this the wrong way then I can close this PR, also not sure if `Animation.empty` or `Animation.none` makse more sense?